### PR TITLE
Downgrade Montoya API version again for better compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("net.portswigger.burp.extensions:montoya-api:2025.7")
+    compileOnly("net.portswigger.burp.extensions:montoya-api:2025.2")
 }
 
 tasks.jar {


### PR DESCRIPTION
No new API features are used. Downgrade to Montoya API v2025.2 for better compatibility.